### PR TITLE
Issue 1 - Fix

### DIFF
--- a/attributes/nodejs.rb
+++ b/attributes/nodejs.rb
@@ -43,3 +43,12 @@ normal['nodejs']['display_name'] = 'Node.js'
 
 # Npm (global modules) home directory
 normal['nodejs']['npm']['home'] = 'C:\\npm'
+
+# Npm (global modules) cache directory
+normal['nodejs']['npm']['cache'] = 'C:\\npm-cache'
+
+# Somewhere outside System32 for the Workgroup\System user profile
+# We set this as an environment variable before running npm.
+# Being inside System32 makes node-gyp's .node-gyp folder unusable by itself.
+# This whole situation is bizzare, but that's how it is.
+normal['nodejs']['sysprof'] = 'C:\\sysprof'

--- a/recipes/couchdb_bootstrap.rb
+++ b/recipes/couchdb_bootstrap.rb
@@ -33,7 +33,11 @@ end
 # TODO: Figure out better npm path solution.
 # The not_if should really just be `Get-Command couchdb-bootstrap`
 powershell_script 'install_couchdb_bootstrap' do
-  code 'npm install -g --silent couchdb-bootstrap'
+  # See nodejs_deploy.rb for a longer explanation of this insanity.
+  code "$env:USERPROFILE = \"#{node['nodejs']['sysprof']}\";" \
+  "$env:NPM_CONFIG_PREFIX = \"#{node['nodejs']['npm']['home']}\";" \
+  "$env:NPM_CONFIG_CACHE = \"#{node['nodejs']['npm']['cache']}\";" \
+  "npm install -g --loglevel error couchdb-bootstrap;"
   cwd "#{work}/couchdb"
   action :run
   not_if 'Get-Command couchdb-bootstrap'

--- a/recipes/nodejs.rb
+++ b/recipes/nodejs.rb
@@ -38,12 +38,6 @@ windows_path node['nodejs']['home'] do
   action [:remove, :add]
 end
 
-# Ensure Npm's home directory is global, and avoid %AppData%
-powershell_script 'set_npm_prefix' do
-  code "npm config set prefix #{node['nodejs']['npm']['home']}"
-  action :run
-end
-
 # Add Npm's home directory to the Windows path, and to Ruby's ENV
 windows_path node['nodejs']['npm']['home'] do
   action [:remove, :add]


### PR DESCRIPTION
https://github.com/Tour-de-Force/btc-infrastructure/issues/1

Set USERPROFILE environment variable to a directory outside System32. When the Workgroup/System user was running Chef and had its home folder inside System32, node-gyp was getting sad. Node-gyp attempts to build native dependencies and was keeping some config data in USERPROFILE. It was the thing supposedly failing on Python not being installed. When its USERPROFILE is outside System32 it seems to be able to handle itself.

However, the dependency that needs node-gyp (leveldown depended on by the PouchDB package) is still failing to build for another reason, but it is an optional dependency. This failure was causing a nonzero return from the Powershell script, so we can force "exit 0" from that script until we fix the dependency. We will just have to check that the server is really running after deploying in the meantime. I will write a **new bug** for this build fix if we're okay with how it is for now.

Also set the npm prefix and cache paths with environment variables instead of depending on it finding the right config files with all this System32 nonsense going on. Environment variables are the highest precedence for npm too; so we can be more sure they will be honored.

I was able to deploy 2 new web servers and 2 new database servers with this patch.
