### PR TITLE
[UNFINISHED] Attempted securing traffic directly from Couch and BTC-App servers (behind load balancers).

### DIFF
--- a/attributes/couchdb.rb
+++ b/attributes/couchdb.rb
@@ -41,4 +41,4 @@ normal['couchdb']['home'] = 'C:\CouchDB'
 normal['couchdb']['bind_address'] = '0.0.0.0'
 
 # <> Defines the IP address by which CouchDB will be accessible.
-normal['couchdb']['port'] = 5984
+normal['couchdb']['port'] = 6984

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,5 +25,8 @@ normal['server']['dir'] = 'C:\Server'
 # <> Directory in which to perform other work related to chef
 normal['work']['dir'] = 'C:\Work'
 
+# <> Directory in which to store certificate related files
+normal['certificates']['dir'] = 'C:\Certificates'
+
 # <> Array of admin users as {:username, :password} hashes
 default['admin_users'] = []

--- a/recipes/couchdb.rb
+++ b/recipes/couchdb.rb
@@ -48,9 +48,9 @@ end
 
 # Allow incoming HTTP on Couch's default port
 netsh_firewall_rule 'Apache CouchDB' do
-  description 'Allow HTTP connections to CouchDB on TCP port 5984'
+  description 'Allow HTTPS connections to CouchDB on TCP port 6984'
   dir :in
-  localport '5984'
+  localport '6984'
   protocol :tcp
   action :allow
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,6 +16,46 @@
 # You should have received a copy of the Affero GNU General Public License
 # along with btc_infrastructure.  If not, see <http://www.gnu.org/licenses/>.
 
+log 'creating installer directory'
+
 directory node['installers']['dir'] do
   action :create
+end
+
+log 'copying ssl certificate and key'
+
+# The app name we're expecting to configure
+app_name = node['server']['name']
+app = search('aws_opsworks_app', "name:#{app_name}").first
+
+# Only configure SSL if the incoming app name matches our expected app name
+# and it wants SSL
+if app && app['enable_ssl'] == true
+	directory node['certificates']['dir'] do
+  		action :create
+	end
+
+	# save the certificate
+	cert_path = File.join(node['certificates']['dir'], 'server.cert')
+	file cert_path do
+		content app['ssl_configuration']['certificate']
+		sensitive true
+	end
+
+	env 'SERVER_CERTIFICATE_FILE' do
+		value cert_path
+		action :create
+	end
+
+	#save the private key
+	key_path = File.join(node['certificates']['dir'], 'server.key')
+	file key_path do
+		content app['ssl_configuration']['private_key']
+		sensitive true
+	end
+
+	env 'SERVER_KEY_FILE' do
+		value key_path
+		action :create
+	end
 end

--- a/recipes/nodejs_deploy.rb
+++ b/recipes/nodejs_deploy.rb
@@ -28,9 +28,9 @@ if app && app['deploy'] == true
 
   # Allow incoming HTTP on Couch's default port
   netsh_firewall_rule 'Node.js App Server' do
-    description 'Allow HTTP connections to the App Server on TCP port 80'
+    description 'Allow HTTPS connections to the App Server on TCP port 8443'
     dir :in
-    localport '80'
+    localport '8443'
     protocol :tcp
     action :allow
   end

--- a/templates/default/local.ini.erb
+++ b/templates/default/local.ini.erb
@@ -5,7 +5,6 @@
 ; overwritten on server upgrade.
 
 [httpd]
-port = <%= node.couchdb.port %>
 bind_address = <%= node.couchdb.bind_address %>
 enable_cors = true
 
@@ -19,3 +18,13 @@ origins = *
 <% node.admin_users.each do |admin_user| -%>
 <%= admin_user[:username] %> = <%= admin_user[:password] %>
 <% end -%>
+
+[daemons]
+httpsd = {couch_httpd, start_link, [https]}
+
+[ssl]
+; These paths have to be entered in this non-standard way, so we hard-code
+; them in the Chef script.
+cert_file = C:/Certificates/server.cert
+key_file = C:/Certificates/server.key
+port = <%= node.couchdb.port %>


### PR DESCRIPTION
DO NOT MERGE.

- Copies SSL certificate and private key files to the 2 server types.
- Changes port in configuration for Couch.
- Adds reference to SSL certificates to configuration for Couch.
- Note: Some other server parameters were changed in the server repo.

IMPORTANT: This patch doesn't work yet. The servers are both having trouble actually serving in the AWS environment. This might not be the best way to do this anyway. It might be better to use Nginx or some other server as a reverse proxy locally to handle SSL.

https://github.com/Tour-de-Force/btc-infrastructure/issues/6